### PR TITLE
Support Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,8 @@
   ],
   "require": {
     "php": "^7.1|^8.0",
-    "illuminate/support": "5.*|6.*|7.*|8.*",
-    "illuminate/console": "5.*|6.*|7.*|8.*"
-  },
-  "require-dev": {
-    "mockery/mockery": ">=0.9.9",
-    "phpunit/phpunit": ">=4.1",
-    "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0"
+    "illuminate/support": "5.*|6.*|7.*|8.*|9.*",
+    "illuminate/console": "5.*|6.*|7.*|8.*|9.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
I also removed the `require-dev` section since the package doesn't have any tests. Let me know if you'd want this back.